### PR TITLE
take error class into account when generating fingerprint

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -13,6 +14,14 @@ type CustomError struct {
 }
 
 func (e *CustomError) Error() string {
+	return e.s
+}
+
+type CustomError2 struct {
+	s string
+}
+
+func (e *CustomError2) Error() string {
 	return e.s
 }
 
@@ -196,4 +205,33 @@ func TestErrorRead(t *testing.T) {
 	post(nil)
 
 	Wait()
+}
+
+func TestFingerprint(t *testing.T) {
+	stack1 := Stack{Frame{"foo.go", "Oops", 1}}
+	stack2 := Stack{Frame{"bar.go", "Womp", 2}}
+
+	customErrorInstance := &CustomError{"foo"}
+	customErrorInstance2 := &CustomError{"bar"}
+
+	// fingerprint should be the same for same error class, same stack
+	assertEqual(t,
+		fingerprint(stack1, customErrorInstance),
+		fingerprint(stack1, customErrorInstance2))
+	// but different for same error class, different stack
+	assertNotEqual(t,
+		fingerprint(stack1, customErrorInstance),
+		fingerprint(stack2, customErrorInstance2))
+}
+
+func assertEqual(t *testing.T, got, want interface{}) {
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %s, wanted %s", got, want)
+	}
+}
+
+func assertNotEqual(t *testing.T, got, want interface{}) {
+	if reflect.DeepEqual(got, want) {
+		t.Errorf("expected %s, wanted %s", got, want)
+	}
 }


### PR DESCRIPTION
previously, this reporter was grouping together errors only using the
stack trace. this was insufficient for our programs because errors can
have similar stack traces when lacking pkg/errors backtraces.

the rollbar documentation mentions using the error class as part of the
fingerprint, so it makes sense to conform to that.

---

@ejholmes i tried to do this in a way that didn't involve forking this library by injecting in a fingerprint. but in most of our use cases, we actually don't pass in a stack, so stvp/rollbar generates its own stack based on where the error is being reported from. it made much more sense to just fix the fingerprint sending.

actually, according to the docs (https://rollbar.com/docs/grouping-algorithm/), rollbar will use its own grouping algorithm which is more sophisticated than this one. i kinda want to just remove the fingerprint sending. will open up a separate PR for that one and we can choose which one we want :)

https://github.com/remind101/rollbar/pull/2